### PR TITLE
Changed connection abstraction

### DIFF
--- a/ADatabaseFixture.FluentMigrator.Tests/Core/DatabaseTest.cs
+++ b/ADatabaseFixture.FluentMigrator.Tests/Core/DatabaseTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using DataDude;
+using Microsoft.Data.SqlClient;
 using Respawn;
 using Xunit;
 
@@ -19,6 +20,8 @@ namespace ADatabaseFixture.FluentMigrator.Tests.Core
         public Dude Dude { get; }
 
         private static Respawner Respawner { get; set; }
+
+        protected SqlConnection CreateNewConnection() => new(Fixture.ConnectionString);
 
         public async Task InitializeAsync()
         {

--- a/ADatabaseFixture.FluentMigrator.Tests/Core/DatabaseTest.cs
+++ b/ADatabaseFixture.FluentMigrator.Tests/Core/DatabaseTest.cs
@@ -21,8 +21,6 @@ namespace ADatabaseFixture.FluentMigrator.Tests.Core
 
         private static Respawner Respawner { get; set; }
 
-        protected SqlConnection CreateNewConnection() => new(Fixture.ConnectionString);
-
         public async Task InitializeAsync()
         {
             Respawner ??= await Respawner.CreateAsync(Fixture.ConnectionString, new RespawnerOptions

--- a/ADatabaseFixture.FluentMigrator/ADatabaseFixture.FluentMigrator.csproj
+++ b/ADatabaseFixture.FluentMigrator/ADatabaseFixture.FluentMigrator.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/ADatabaseFixture.GalacticWasteManagement/ADatabaseFixture.GalacticWasteManagement.csproj
+++ b/ADatabaseFixture.GalacticWasteManagement/ADatabaseFixture.GalacticWasteManagement.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/ADatabaseFixture.SqlServer/ADatabaseFixture.SqlServer.csproj
+++ b/ADatabaseFixture.SqlServer/ADatabaseFixture.SqlServer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ADatabaseFixture.SqlServer/SqlServerDatabaseAdapter.cs
+++ b/ADatabaseFixture.SqlServer/SqlServerDatabaseAdapter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Data;
+using System.Data.Common;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -51,7 +51,8 @@ namespace ADatabaseFixture
             return GetDatabaseConnectionString();
         }
 
-        public virtual IDbConnection CreateNewConnection(string connectionString) => new SqlConnection(connectionString);
+        public virtual SqlConnection CreateNewConnection(string connectionString) => new(connectionString);
+        DbConnection IDatabaseAdapter.CreateNewConnection(string connectionString) => CreateNewConnection(connectionString);
 
         /// <summary>
         /// Kills open connections, Drops database and tries to remove the file
@@ -100,6 +101,7 @@ namespace ADatabaseFixture
                 SELECT @kill = @kill + 'kill ' + CONVERT(varchar(5), session_id) + ';'  
                 FROM sys.dm_exec_sessions
                 WHERE database_id  = db_id('{_databaseName}')
+                AND is_user_process = 1;
                 EXEC(@kill);
                 """;
             await cmd.ExecuteNonQueryAsync();

--- a/ADatabaseFixture/ADatabaseFixture.csproj
+++ b/ADatabaseFixture/ADatabaseFixture.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/ADatabaseFixture/DatabaseFixtureBase.cs
+++ b/ADatabaseFixture/DatabaseFixtureBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace ADatabaseFixture
@@ -26,7 +27,7 @@ namespace ADatabaseFixture
         /// <summary>
         /// Creates a new open connection
         /// </summary>
-        public virtual IDbConnection CreateNewConnection()
+        public virtual DbConnection CreateNewConnection()
         {
             var connection = _databaseAdapter.CreateNewConnection(ConnectionString);
             if (connection.State != ConnectionState.Open)

--- a/ADatabaseFixture/IDatabaseAdapter.cs
+++ b/ADatabaseFixture/IDatabaseAdapter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 
 namespace ADatabaseFixture
@@ -21,6 +22,6 @@ namespace ADatabaseFixture
         /// </summary>
         /// <param name="connectionString">Connection string</param>
         /// <returns>New connection</returns>
-        IDbConnection CreateNewConnection(string connectionString);
+        DbConnection CreateNewConnection(string connectionString);
     }
 }


### PR DESCRIPTION
Changing connection abstraction from `IDbConnection` to `DbConnection` in order to improve what downstream dependencies can do with the connection