### PR TITLE
Updated Microsoft.Data.SqlClient and FluentMigrator.Runner dependencis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
+  DOTNET_VERSION: '8.x' # The .NET SDK version to use
 
 jobs:
   build-and-test:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        dotnet: [ '2.x', '6.x', '7.x' ]
+        dotnet: [ '2.x', '6.x', '8.x' ]
         os: [windows-latest]
 
     steps:

--- a/.github/workflows/release-adatabasefixture-fluentmigrator.yml
+++ b/.github/workflows/release-adatabasefixture-fluentmigrator.yml
@@ -6,7 +6,7 @@ on:
     - 'fluentmigrator-*'
 
 env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
+  DOTNET_VERSION: '8.x' # The .NET SDK version to use
 
 jobs:
 

--- a/.github/workflows/release-adatabasefixture-galacticwastemanagement.yml
+++ b/.github/workflows/release-adatabasefixture-galacticwastemanagement.yml
@@ -6,7 +6,7 @@ on:
     - 'galacticwastemanagement-*'
 
 env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
+  DOTNET_VERSION: '8.x' # The .NET SDK version to use
 
 jobs:
 

--- a/.github/workflows/release-adatabasefixture-sqlserver.yml
+++ b/.github/workflows/release-adatabasefixture-sqlserver.yml
@@ -6,7 +6,7 @@ on:
     - 'sqlserver-*'
 
 env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
+  DOTNET_VERSION: '8.x' # The .NET SDK version to use
 
 jobs:
 

--- a/.github/workflows/release-adatabasefixture.yml
+++ b/.github/workflows/release-adatabasefixture.yml
@@ -6,7 +6,7 @@ on:
     - 'adatabasefixture-*'
 
 env:
-  DOTNET_VERSION: '7.x' # The .NET SDK version to use
+  DOTNET_VERSION: '8.x' # The .NET SDK version to use
 
 jobs:
 

--- a/ADatabaseFixture.FluentMigrator.Tests/ADatabaseFixture.FluentMigrator.Tests.csproj
+++ b/ADatabaseFixture.FluentMigrator.Tests/ADatabaseFixture.FluentMigrator.Tests.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" Version="2.1.28" />
 	  <PackageReference Include="DataDude" Version="0.7.2" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Respawn" Version="6.0.0" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Respawn" Version="6.2.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ADatabaseFixture.FluentMigrator/ADatabaseFixture.FluentMigrator.csproj
+++ b/ADatabaseFixture.FluentMigrator/ADatabaseFixture.FluentMigrator.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentMigrator.Runner" Version="3.3.2" />
+    <PackageReference Include="FluentMigrator.Runner" Version="5.0.0" />
     <ProjectReference Include="..\ADatabaseFixture\ADatabaseFixture.csproj" />
   </ItemGroup>
 

--- a/ADatabaseFixture.FluentMigrator/FluentMigratorMigrator.cs
+++ b/ADatabaseFixture.FluentMigrator/FluentMigratorMigrator.cs
@@ -32,7 +32,7 @@ namespace ADatabaseFixture.FluentMigrator
                 .BuildServiceProvider(false);
 
             using var scope = serviceProvider.CreateScope();
-            scope.ServiceProvider.GetService<IMigrationRunner>().MigrateUp();
+            scope.ServiceProvider.GetRequiredService<IMigrationRunner>().MigrateUp();
             return Task.CompletedTask;
 
         }

--- a/ADatabaseFixture.GalacticWasteManagement.Tests/ADatabaseFixture.GalacticWasteManagement.Tests.csproj
+++ b/ADatabaseFixture.GalacticWasteManagement.Tests/ADatabaseFixture.GalacticWasteManagement.Tests.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="DataDude" Version="0.7.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Respawn" Version="6.0.0" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Respawn" Version="6.2.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ADatabaseFixture.SqlServer/ADatabaseFixture.SqlServer.csproj
+++ b/ADatabaseFixture.SqlServer/ADatabaseFixture.SqlServer.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ADatabaseFixture.SqlServer/SqlServerDatabaseAdapter.cs
+++ b/ADatabaseFixture.SqlServer/SqlServerDatabaseAdapter.cs
@@ -36,9 +36,9 @@ namespace ADatabaseFixture
             var filePath = GetDatabasePath();
             string connectionString = GetMasterConnectionString();
 #if NETSTANDARD2_1_OR_GREATER
-            await using var connection = new SqlConnection(connectionString);
+            await using var connection = CreateNewConnection(connectionString);
 # else
-            using var connection = new SqlConnection(connectionString);
+            using var connection = CreateNewConnection(connectionString);
 #endif
             await connection.OpenAsync();
 #if NETSTANDARD2_1_OR_GREATER
@@ -61,9 +61,9 @@ namespace ADatabaseFixture
         {
             string connectionString = GetMasterConnectionString();
 #if NETSTANDARD2_1_OR_GREATER
-            await using var connection = new SqlConnection(connectionString);
+            await using var connection = CreateNewConnection(connectionString);
 #else
-            using var connection = new SqlConnection(connectionString);
+            using var connection = CreateNewConnection(connectionString);
 #endif
             await connection.OpenAsync();
             await KillOpenConnections(connection);


### PR DESCRIPTION
- `Microsoft.Data.SqlClient` updated from `5.1.0` (which had [a vulnerability](https://github.com/dotnet/announcements/issues/292)) to `5.1.4`.
- `FluentMigrator.Runner` updated from `3.3.2` to `5.0.0`
- Building packages using dotnet 8 instead of 7